### PR TITLE
Reduce science convention event appearance rate

### DIFF
--- a/events/mem_sciencecon_events.txt
+++ b/events/mem_sciencecon_events.txt
@@ -53,11 +53,14 @@ country_event = {
   show_sound = event_default
   
   mean_time_to_happen = {
-    months = 120
+    months = 600
   }
 
   trigger = {
     is_ai = no
+	num_communications > 7
+	num_owned_planets > 3
+	is_at_war = no
     NOT = {
       OR = {        
         has_country_flag = mem_sciencecon_denied


### PR DESCRIPTION
Science convention was happening way too much. Up MTTH to 50 years
and require 4 planets, 8 communications, and no war to start event.

Partially addresses Issue #29 
