### PR TITLE
Expanding the event chains

### DIFF
--- a/common/special_projects/enterprise_fallen_projects.txt
+++ b/common/special_projects/enterprise_fallen_projects.txt
@@ -1,0 +1,30 @@
+######################
+# Enterprise of the Fallen
+# Special Project
+######################
+
+# Starship of the Fallen
+special_project = {
+	key = "EF_TEMP_PROJECT"
+	cost = 0
+	days_to_research = 90
+	tech_department = society_technology
+	picture = GFX_evt_society_research
+	icon = "gfx/interface/icons/situation_log/situation_log_quest.dds"
+
+	event_scope = ship_event
+
+	requirements = {
+		shipclass_science_ship = 1
+		leader = scientist
+		skill > 1
+	}
+	
+	on_success = {
+		ship_event = { id = ef_temp.4 }
+	}
+	
+	on_fail = {
+	}
+	
+}

--- a/common/static_modifiers/enterprise_fallen_static_modifiers.txt
+++ b/common/static_modifiers/enterprise_fallen_static_modifiers.txt
@@ -1,0 +1,12 @@
+###############################
+# Spiritualist pilgrimage
+###############################
+
+boldly_going = {
+	pop_happiness = 0.05
+	pop_ethic_shift = -0.05
+}
+
+malicious_joy = {
+	pop_happiness = 0.10
+}

--- a/events/ef_debug.txt
+++ b/events/ef_debug.txt
@@ -1,0 +1,27 @@
+namespace = ef_debug
+
+country_event = {
+	id = ef_debug.1
+	hide_window = yes
+	
+	is_triggered_only = yes
+	
+	immediate = {
+		ROOT = {
+			country_add_ethic = "ethic_xenophobe"
+		}
+	}
+}
+
+country_event = {
+	id = ef_debug.2
+	hide_window = yes
+	
+	is_triggered_only = yes
+	
+	immediate = {
+		ROOT = {
+			country_add_ethic = "ethic_xenophile"
+		}
+	}
+}

--- a/events/enterprise_fallen.txt
+++ b/events/enterprise_fallen.txt
@@ -1,8 +1,8 @@
 ################################
 # Enterprise of the Fallen
-# Original idea by: Mourn
+# Original idea by: Talanic 
 # Code by:          Tuttu
-# Writing by:       Elimdur
+# Writing by:       Malthus
 ################################
 
 namespace = ef_temp
@@ -22,10 +22,14 @@ ship_event = {
 			orbital_deposit_tile = { clear_deposits = yes } 
 			save_event_target_as = ruins_planet
 		}
+		hidden_effect = {
+			ship_event = { id = ef_temp.3 days = 1800 random = 540 } # 5 years +/- 1,5 years
+			#ship_event = { id = ef_temp.3 days = 10 random = 2 } # 5 years +/- 1,5 years
+		}
 	}
 	
 	option = {
-		name = INCREDIBLE
+		name = "INCREDIBLE"
 		FROM = { 
 			orbital_deposit_tile = { 
 				add_deposit = d_immense_society_deposit
@@ -46,5 +50,128 @@ ship_event = {
 			
 	option = {
 		name = "UNFORTUNATE"
+	}
+}
+
+# ~5 years past. Requesting additionnal research
+ship_event = {
+	id = ef_temp.3
+	title = "ef_temp.3.name"
+	desc = "ef_temp.3.desc"
+	picture = GFX_evt_city_ruins
+	location = event_target:ruins_planet
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = "ef_temp.3.a"
+		event_target:ruins_planet = {
+			enable_special_project = {
+				name = "EF_TEMP_PROJECT"
+				owner = ROOT
+				location = event_target:ruins_planet
+			}
+		}
+	}
+}
+
+# Special project completed
+ship_event = {
+	id = ef_temp.4
+	title = "ef_temp.4.name"
+	desc = {
+		text = ef_temp.4.desc_default
+		trigger = {		  
+			root.owner = {
+				NOR = {   				
+					has_ethic = "ethic_xenophile"
+					has_ethic = "ethic_fanatic_xenophile"
+					has_ethic = "ethic_xenophobe"
+					has_ethic = "ethic_fanatic_xenophobe"
+				}
+			}
+		}
+	}
+	desc = {
+		text = ef_temp.4.desc_xenophile
+		trigger = {	
+			root.owner = {
+				OR = {        
+					has_ethic = "ethic_xenophile"
+					has_ethic = "ethic_fanatic_xenophile"
+				}
+			}
+		}
+	}
+	desc = {
+		text = ef_temp.4.desc_xenophobe
+		trigger = {		  
+			root.owner = {
+				OR = {        
+					has_ethic = "ethic_xenophobe"
+					has_ethic = "ethic_fanatic_xenophobe"
+				}
+			}
+		}
+	}
+	picture = GFX_evt_ship_in_orbit
+	location = FROM
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = "ef_temp.4.a"
+		root.owner = { add_energy = 250 }
+	}
+	# Available only for Xenophile
+	option = {
+		name = "ef_temp.4.b"
+		trigger = {
+			root.owner = {
+				OR = {
+					has_ethic = "ethic_xenophile"
+					has_ethic = "ethic_fanatic_xenophile"
+				}
+			}		
+		}
+		custom_tooltip = ef_temp.4.b.tooltip
+		hidden_effect = {
+			root.owner = {
+				every_owned_pop = {
+					limit = {
+						OR = {
+							has_ethic = "ethic_xenophile"
+							has_ethic = "ethic_fanatic_xenophile"
+							has_ethic = "ethic_pacifist"
+							has_ethic = "ethic_fanatic_pacifist"
+						}
+					}
+					add_modifier = {
+						modifier = "boldly_going"
+						days = 360
+					}
+				}
+			}
+		}
+	}
+	# Available only for Xenophobe
+	option = {
+		name = "ef_temp.4.c"
+		trigger = {
+			root.owner = {
+				OR = {
+					has_ethic = "ethic_xenophobe"
+					has_ethic = "ethic_fanatic_xenophobe"
+				}
+			}		
+		}
+		root.owner = {
+			every_owned_pop = {
+				add_modifier = {
+					modifier = "malicious_joy"
+					days = 360
+				}
+			}	
+		}
 	}
 }

--- a/localisation/enterprise_fallen_l_english.yml
+++ b/localisation/enterprise_fallen_l_english.yml
@@ -3,5 +3,26 @@
  ef_temp_category_desc:0 "Our survey team has found some relatively intact buildings on §Y[ruins_planet.GetName]§! that should be worth investigating."
  ef_temp.1.name:0 "The Great Library"
  ef_temp.1.desc:0 "Our science team literally hit the jackpot. The ancient building complex they were exploring has turned out to be some kind of great library of this ancient civilisation. It will take years if not decades to study everything that is stored there."
+ 
  ef_temp.2.name:0 "No New Findings"
  ef_temp.2.desc:0 "Although those ancient buildings were relatively intact, our science team could not find anything to further our knowledge about their former residents. All personnel is back on board the §Y[Root.GetName]§! and ready to move on."
+ 
+ ef_temp.3.name:0 "Starship of the Fallen"
+ ef_temp.3.desc:0 "Further studying of this tomb world and the found historical documents has indicated that its former inhabitants may have been more advanced than we previously thought. Documents and schematics recovered from the surface include detailed examinations of an advanced starship. This may merit further investigation."
+ ef_temp.3.a:0 "Interesting indeed."
+ 
+ EF_TEMP_PROJECT:0 "Starship of the Fallen"
+ EF_TEMP_PROJECT_DESC:0 "Our Science teams working on §Y[ruins_planet.GetName]§! are requesting additional personnel to find out more about this ship and its possible location."
+ 
+ ef_temp.4.name:0 "Starship of the Fallen"
+ ef_temp.4.desc_default:0 "Investigations turned up a detailed archive which may take years to study in full. However, the immediate conclusion is clear: The vessel known as the "Project" does not exist.\n\nIt never did. The inhabitants of §Y[ruins_planet.GetName]§! had very creative imaginations and had fantasized heavily about exploring space. The "Project" was the fictional ship that blazed a trail into the stars.\nThere is no research data to be gleaned from analysis of the archive, but it may be of interest to a collector or the entertainment industry."
+ ef_temp.4.desc_xenophile:0 "Investigations turned up a detailed archive which may take years to study in full. However, the immediate conclusion is clear: The vessel known as the "Activity" does not exist.\n\nWhat a pity. The inhabitants of §Y[ruins_planet.GetName]§! were much like ourselves. They dreamed of strange new worlds and civilisations, and created a lengthy serial adventure story about what they thought space would be like. The Starship Activity and its intrepid captain would fit right into our navy - if only the people of §Y[ruins_planet.GetName]§! had survived.\n\nWe will remember them. §Y[Root.GetLeaderName]§! has created a program to translate the archive into our language. Give the order and we will disperse it among the populace.\n\nIf it's popular enough, we could even make new episodes. Let these voyages continue."
+ ef_temp.4.desc_xenophobe:0 "The inhabitants of §Y[ruins_planet.GetName]§! were twisted, even for alien standards. Reviewing their recordings has left §Y[Root.GetLeaderName]§! permanently deranged. Their so called ship now known to us as the "Challenger" was nothing but a soap opera. Still, it's good to see that their folly is written across their planet in nuclear blast craters.\n\nEven though these recordings are useless to our scientists we could edit them for propaganda purposes or simply sell them to ... collectors. Just give the order."
+ ef_temp.4.a:0 "Sell everything to the highest bidder."
+ ef_temp.4.b:0 "Roll the tapes!"
+ ef_temp.4.c:0 "Show our people what happens when purity falters."
+ 
+ ef_temp.4.b.tooltip:0 "Pacifist Pops: §YBoldly Going§! modifier added for §Y12§! months, giving the following effects:\n\nHappiness: §G+5%§!\nEthics Divergence: §G-5%§! "
+ 
+ boldly_going:0 "Boldly Going"
+ malicious_joy:0 "Malicious Joy"


### PR DESCRIPTION
After you found the library, a new event will now appear almost 5 years
later and you can have different outcomes if you are Xenophile or
Xenophobe on top of the default outcome.
This completes this anomaly as long as I don't find a good way to extend
(And not replace like suggested Kyojin) the duration of some outcomes.
If I find nothing, I will use Kyojin's workaround.
