### PR TITLE
Changed tile blocker according to vanilla tb´s

### DIFF
--- a/common/tile_blockers/ancient_robots_tile_blockers.txt
+++ b/common/tile_blockers/ancient_robots_tile_blockers.txt
@@ -1,9 +1,11 @@
 tb_strange_mountain = {
 	picture = tb_mountain_range
-
-	spawn_chance = {
-		# None - Event Only
+	cost = { # Can't be removed
 	}
-
-	prerequisites = {  }
+	
+	spawn_chance = {
+		modifier = {
+			add = 0
+		}
+	}
 }


### PR DESCRIPTION
tb_titanic_life_blocker = { #Added via event
    picture = tb_dangerous_wildlife
    cost = {
    }
    spawn_chance = {
        modifier = {
            add = 0
        }
    }
}

tb_wandering_forest_reserve = {
    picture = tb_dense_jungle 
    cost = { # Can't be removed
    }
    spawn_chance = {
        modifier = {
            add = 0
        }
    }
    adjacency_bonus = {
        resource_society_research_add = 5
    }
}
