### PR TITLE
Ancestor's Grudge relic activation tooltips

### DIFF
--- a/common/scripted_loc/mem_ancestors_grudge_scripted_loc.txt
+++ b/common/scripted_loc/mem_ancestors_grudge_scripted_loc.txt
@@ -3,17 +3,18 @@
 defined_text = {
 	name = MemGetRarity
 	random = no
-	# otherwise the logs start to cry
+    text = {
+        trigger = {
+            is_scope_type = leader
+            NOT = {
+                is_variable_set = mem_ancestors_grudge_smithing_quality_rolled
+            }
+        }
+        localization_key = "[owner.MemGetRarity]"
+    }
 	text = {
 		trigger = {
-			NOT = {
-				is_variable_set = mem_ancestors_grudge_smithing_quality_rolled
-			}
-		}
-		localization_key = mem_ancestors_grudge_empty
-	}
-	text = {
-		trigger = {
+            is_variable_set = mem_ancestors_grudge_smithing_quality_rolled
 			check_variable_arithmetic = {
 				which = this.mem_ancestors_grudge_smithing_quality_rolled
 				value = 6
@@ -23,6 +24,7 @@ defined_text = {
 	}
 	text = {
 		trigger = {
+            is_variable_set = mem_ancestors_grudge_smithing_quality_rolled
 			check_variable_arithmetic = {
 				which = this.mem_ancestors_grudge_smithing_quality_rolled
 				value = 5
@@ -32,6 +34,7 @@ defined_text = {
 	}
 	text = {
 		trigger = {
+            is_variable_set = mem_ancestors_grudge_smithing_quality_rolled
 			check_variable_arithmetic = {
 				which = this.mem_ancestors_grudge_smithing_quality_rolled
 				value = 4
@@ -41,6 +44,7 @@ defined_text = {
 	}
 	text = {
 		trigger = {
+            is_variable_set = mem_ancestors_grudge_smithing_quality_rolled
 			check_variable_arithmetic = {
 				which = this.mem_ancestors_grudge_smithing_quality_rolled
 				value = 3
@@ -50,6 +54,7 @@ defined_text = {
 	}
 	text = {
 		trigger = {
+            is_variable_set = mem_ancestors_grudge_smithing_quality_rolled
 			check_variable_arithmetic = {
 				which = this.mem_ancestors_grudge_smithing_quality_rolled
 				value = 2
@@ -59,6 +64,7 @@ defined_text = {
 	}
 	text = {
 		trigger = {
+            is_variable_set = mem_ancestors_grudge_smithing_quality_rolled
 			check_variable_arithmetic = {
 				which = this.mem_ancestors_grudge_smithing_quality_rolled
 				value = 1
@@ -68,6 +74,7 @@ defined_text = {
 	}
 	text = {
 		trigger = {
+            is_variable_set = mem_ancestors_grudge_smithing_quality_rolled
 			check_variable_arithmetic = {
 				which = this.mem_ancestors_grudge_smithing_quality_rolled
 				value = 0

--- a/events/mem_ancestors_grudge_events.txt
+++ b/events/mem_ancestors_grudge_events.txt
@@ -2651,6 +2651,46 @@ country_event = {
 				LEADER = scientist
 			}
 		}
+        # machine leader assembly, won't show up in the tooltip if you create the leader in the option
+        if = {
+            limit = {
+                has_authority = auth_machine_intelligence
+            }
+            remove_saved_leader = mem_ancestors_grudge_assembled_leader
+            switch = {
+                trigger = has_relic
+                r_mem_ancestors_grudge_pauldron = {
+                    create_saved_leader = {
+                        class = official
+                        species = root.owner_main_species
+                        key = mem_ancestors_grudge_assembled_leader
+                        effect = {
+                            save_event_target_as = mem_ancestors_grudge_assembled_leader
+                        }
+                    }
+                }
+                r_mem_ancestors_grudge_sword = {
+                    create_saved_leader = {
+                        class = commander
+                        species = root.owner_main_species
+                        key = mem_ancestors_grudge_assembled_leader
+                        effect = {
+                            save_event_target_as = mem_ancestors_grudge_assembled_leader
+                        }
+                    }
+                }
+                r_mem_ancestors_grudge_ring = {
+                    create_saved_leader = {
+                        class = scientist
+                        species = root.owner_main_species
+                        key = mem_ancestors_grudge_assembled_leader
+                        effect = {
+                            save_event_target_as = mem_ancestors_grudge_assembled_leader
+                        }
+                    }
+                }
+            }
+        }
 		set_variable = {
 			which = mem_ancestors_grudge_activated_rune_ruler_strength
 			value = 0
@@ -2806,41 +2846,17 @@ country_event = {
 			}
 		}
 		custom_tooltip = mem_ancestors_grudge.45.ee.tt_create_leader
-		hidden_effect = {
-			if = {
-				limit = {
-					has_relic = r_mem_ancestors_grudge_pauldron
-				}
-				create_leader = {
-					class = official
-					species = root.owner_main_species
-				}
-			}
-			else_if = {
-				limit = {
-					has_relic = r_mem_ancestors_grudge_sword
-				}
-				create_leader = {
-					class = commander
-					species = root.owner_main_species
-				}
-			}
-			else_if = {
-				limit = {
-					has_relic = r_mem_ancestors_grudge_ring
-				}
-				create_leader = {
-					class = scientist
-					species = root.owner_main_species
-				}
-			}
-			last_created_leader = {
-				set_age = 0
-				set_skill = 3
-				#set_name = rand
-				mem_ancestors_grudge_trait_effect = yes
-			}
-		}
+        event_target:mem_ancestors_grudge_assembled_leader = {
+            mem_ancestors_grudge_trait_effect = yes
+        }
+        activate_saved_leader = {
+            key = mem_ancestors_grudge_assembled_leader
+            effect = {
+                set_age = 0
+                set_skill = 3
+                #set_name = rand
+            }
+        }
 	}
 	option = {
 		name = mem_ancestors_grudge.45.e.3


### PR DESCRIPTION
Implemented the trait tooltips for machines when assembling leaders using the relics as the organic part was already in the repo.

Also fixed the quality not showing up in the tooltip.

<img width="570" height="329" alt="Untitled" src="https://github.com/user-attachments/assets/e43a6833-6b43-4a5f-b29a-2242b59c3dc5" />
